### PR TITLE
Adoption app improvement

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
  *= require_self
  */
  @import "bootstrap";
+ 

--- a/app/controllers/adopter_applications_controller.rb
+++ b/app/controllers/adopter_applications_controller.rb
@@ -1,3 +1,4 @@
+# allows adopter users to create an adoption application and/or update status to 'withdrawn'
 class AdopterApplicationsController < ApplicationController
   before_action :authenticate_user!
   before_action :adopter_with_profile
@@ -20,20 +21,21 @@ class AdopterApplicationsController < ApplicationController
     end
   end
 
+  # update :status to 'withdrawn' or :profile_show to false
   def update
     @application = AdopterApplication.find(params[:id])
 
     if @application.update(application_params)
-      redirect_to profile_path, notice: 'Application withdrawn.'
+      redirect_to profile_path
     else
-      redirect_to profile_path, notice: 'Error removing application.'
+      redirect_to profile_path, notice: 'Error.'
     end
   end
 
   private
 
   def application_params
-    params.permit(:dog_id, :adopter_account_id, :status, :profile_show)
+    params.permit(:id, :dog_id, :adopter_account_id, :status, :profile_show)
   end
 
   def adopter_with_profile

--- a/app/controllers/adopter_applications_controller.rb
+++ b/app/controllers/adopter_applications_controller.rb
@@ -20,20 +20,20 @@ class AdopterApplicationsController < ApplicationController
     end
   end
 
-  def destroy
+  def update
     @application = AdopterApplication.find(params[:id])
 
-    if @application.destroy
+    if @application.update(application_params)
       redirect_to profile_path, notice: 'Application withdrawn.'
     else
-      redirect_to profile_path, notice: 'Error. Please try again.'
+      redirect_to profile_path, notice: 'Error removing application.'
     end
   end
 
   private
 
   def application_params
-    params.permit(:dog_id, :adopter_account_id)
+    params.permit(:dog_id, :adopter_account_id, :status, :profile_show)
   end
 
   def adopter_with_profile

--- a/app/controllers/adopter_applications_controller.rb
+++ b/app/controllers/adopter_applications_controller.rb
@@ -34,6 +34,7 @@ class AdopterApplicationsController < ApplicationController
 
   private
 
+  # check these params are OK. Server output states missing param.
   def application_params
     params.permit(:id, :dog_id, :adopter_account_id, :status, :profile_show)
   end

--- a/app/controllers/adoption_application_reviews_controller.rb
+++ b/app/controllers/adoption_application_reviews_controller.rb
@@ -32,6 +32,7 @@ class AdoptionApplicationReviewsController < ApplicationController
     params.require(:adopter_application).permit(:status, :notes)
   end
 
+  # use where to return a relation for the view
   def selected_dog
     return if !params[:dog_id] || params[:dog_id] == ''
 

--- a/app/controllers/adoption_application_reviews_controller.rb
+++ b/app/controllers/adoption_application_reviews_controller.rb
@@ -35,7 +35,7 @@ class AdoptionApplicationReviewsController < ApplicationController
   def selected_dog
     return if !params[:dog_id] || params[:dog_id] == ''
 
-    Dog.find(params[:dog_id])
+    Dog.where(id: params[:dog_id])
   end
 
   # dogs with same organization_id as current staff && have applications && have no adoption

--- a/app/controllers/adoptions_controller.rb
+++ b/app/controllers/adoptions_controller.rb
@@ -1,11 +1,12 @@
 class AdoptionsController < ApplicationController
 
   #before action - check it's verified staff; check it's for mutual organization
-
+  
   def create
     @adoption = Adoption.new(adoption_params)
 
     if @adoption.save
+      set_statuses_to_adoption_made
       redirect_to adopter_applications_path, notice: 'Dog successfully adopted.'
     else
       redirect_to adopter_applications_path, notice: 'Error. Adoption not saved.'
@@ -19,5 +20,13 @@ class AdoptionsController < ApplicationController
     params.permit(:dog_id, :adopter_account_id)
   end
 
-
+  def set_statuses_to_adoption_made
+    @adoption = Adoption.last
+    @applications = @adoption.dog.adopter_applications
+    @applications.each do |app|
+      unless app.status == 'withdrawn'
+        app.status = 'adoption_made'
+        app.save
+    end
+  end
 end

--- a/app/models/adopter_application.rb
+++ b/app/models/adopter_application.rb
@@ -2,6 +2,6 @@ class AdopterApplication < ApplicationRecord
   belongs_to :dog
   belongs_to :adopter_account
 
-  enum :status, [:awaiting_review, :under_review, :adoption_pending]
+  enum :status, [:awaiting_review, :under_review, :adoption_pending, :withdrawn]
 
 end

--- a/app/models/adopter_application.rb
+++ b/app/models/adopter_application.rb
@@ -2,6 +2,10 @@ class AdopterApplication < ApplicationRecord
   belongs_to :dog
   belongs_to :adopter_account
 
-  enum :status, [:awaiting_review, :under_review, :adoption_pending, :withdrawn]
+  enum :status, [:awaiting_review, 
+                 :under_review,
+                 :adoption_pending,
+                 :withdrawn,
+                 :adoption_made]
 
 end

--- a/app/views/adopter_profiles/_applications.html.erb
+++ b/app/views/adopter_profiles/_applications.html.erb
@@ -3,8 +3,10 @@
     <p>Name: <%= app.dog.name %></p>
     <p>Status: <%= app.status %></p>
     <%= link_to 'See dog', adoptable_dog_path(app.dog.id) %>
-    <%= link_to 'Withdraw', destroy_adopter_application_path(id: app.id),  
-                  data: { turbo_method: "delete",
+    <%= link_to 'Withdraw', update_adopter_application_path(id: app.id, status: 'withdrawn'),  
+                  data: { turbo_method: "patch",
                           turbo_confirm: "Click OK to withdraw this adoption application." } %>
   </div>
 <% end %>
+
+<%# add link to Withdraw that sets the status to 'withdraw' %>

--- a/app/views/adopter_profiles/_applications.html.erb
+++ b/app/views/adopter_profiles/_applications.html.erb
@@ -1,12 +1,19 @@
 <% current_user.adopter_account.adopter_applications.each do | app | %>
-  <div class='card'>
-    <p>Name: <%= app.dog.name %></p>
-    <p>Status: <%= app.status %></p>
-    <%= link_to 'See dog', adoptable_dog_path(app.dog.id) %>
-    <%= link_to 'Withdraw', update_adopter_application_path(id: app.id, status: 'withdrawn'),  
-                  data: { turbo_method: "patch",
-                          turbo_confirm: "Click OK to withdraw this adoption application." } %>
-  </div>
+  <% unless app.profile_show == false %>
+    <div class='card'>
+      <p>Name: <%= app.dog.name %></p>
+      <p>Status: <%= app.status %></p>
+      <%= link_to 'See dog', adoptable_dog_path(app.dog.id) %>
+      <%= link_to 'Withdraw', update_adopter_application_path(id: app.id, status: 'withdrawn'),  
+                    data: { turbo_method: "patch",
+                            turbo_confirm: "Click OK to withdraw this adoption application." } %>
+      <% if app.status == 'withdrawn' || app.status == 'adoption_made' %>
+        <%= link_to 'Remove', update_adopter_application_path(id: app.id, profile_show: false),  
+                      data: { turbo_method: "patch",
+                              turbo_confirm: "Click OK to remove this application." } %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>
 
 <%# add link to Withdraw that sets the status to 'withdraw' %>

--- a/app/views/adopter_profiles/_applications.html.erb
+++ b/app/views/adopter_profiles/_applications.html.erb
@@ -4,9 +4,11 @@
       <p>Name: <%= app.dog.name %></p>
       <p>Status: <%= app.status %></p>
       <%= link_to 'See dog', adoptable_dog_path(app.dog.id) %>
-      <%= link_to 'Withdraw', update_adopter_application_path(id: app.id, status: 'withdrawn'),  
-                    data: { turbo_method: "patch",
-                            turbo_confirm: "Click OK to withdraw this adoption application." } %>
+      <% unless app.status == 'withdrawn' %>
+        <%= link_to 'Withdraw', update_adopter_application_path(id: app.id, status: 'withdrawn'),  
+                      data: { turbo_method: "patch",
+                              turbo_confirm: "If you withdraw you will not be able to reapply for this dog." } %>
+      <% end %>
       <% if app.status == 'withdrawn' || app.status == 'adoption_made' %>
         <%= link_to 'Remove', update_adopter_application_path(id: app.id, profile_show: false),  
                       data: { turbo_method: "patch",
@@ -16,4 +18,4 @@
   <% end %>
 <% end %>
 
-<%# add link to Withdraw that sets the status to 'withdraw' %>
+<%# This currently causes Patch to adopter_profile also, which renders an error in console %>

--- a/app/views/adopter_profiles/_applications.html.erb
+++ b/app/views/adopter_profiles/_applications.html.erb
@@ -2,9 +2,9 @@
   <% unless app.profile_show == false %>
     <div class='card'>
       <p>Name: <%= app.dog.name %></p>
-      <p>Status: <%= app.status %></p>
+      <p>Status: <%= app.status.titleize %></p>
       <%= link_to 'See dog', adoptable_dog_path(app.dog.id) %>
-      <% unless app.status == 'withdrawn' %>
+      <% unless app.status == 'withdrawn' || app.status == 'adoption_made' %>
         <%= link_to 'Withdraw', update_adopter_application_path(id: app.id, status: 'withdrawn'),  
                       data: { turbo_method: "patch",
                               turbo_confirm: "If you withdraw you will not be able to reapply for this dog." } %>

--- a/app/views/adoption_application_reviews/_search_results.html.erb
+++ b/app/views/adoption_application_reviews/_search_results.html.erb
@@ -5,16 +5,23 @@
   <% @dogs.each do |dog| %>
     <%= link_to dog.name, dog_path(dog) %>
     
-    <div class='card'>
+    <div class='card mb-4'>
       <% dog.adopter_applications.each do |app|%>
-      <p>Application Status: <%= app.status.titleize %></p>
-      <p>Applicant Profile: <%= link_to 'Adopter Profile', 
-                                        profile_review_path(app.adopter_account.adopter_profile.id) %>
-      <%= link_to 'Edit Application', edit_adopter_application_path(app.id) %>
-      <%= link_to 'Adoption', create_adoption_path(dog_id: dog.id, 
-                                                   adopter_account_id: app.adopter_account.id),
-                                                   data: { turbo_method: :post, 
-                                                           turbo_confirm: "Click OK to finalize this adoption." } %>
+        <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>"> 
+          Application Status: <%= app.status.titleize%>
+        </div>
+    
+        <div class='mb-3'>
+          <%= link_to 'Adopter Profile', profile_review_path(app.adopter_account.adopter_profile.id) %>
+          <%= link_to 'Edit Application', edit_adopter_application_path(app.id) %>
+
+          <% if app.status == 'adoption_made' %>
+            <%= link_to 'Adoption', create_adoption_path(dog_id: dog.id, 
+                                                        adopter_account_id: app.adopter_account.id),
+                                                        data: { turbo_method: :post, 
+                                                                turbo_confirm: "Click OK to finalize this adoption." } %>
+          <% end %>
+        </div>
       <% end %>
     </div>
 
@@ -26,7 +33,7 @@
     
     <div class='card'>
       <% @dog.adopter_applications.each do |app|%>
-      <p>Application Status: <%= app.status.titleize %></p>
+      <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>"> Application Status: <%= app.status.titleize%></div>
       <p>Applicant Profile: <%= link_to 'Adopter Profile', 
                                         profile_review_path(app.adopter_account.adopter_profile.id) %>
       <%= link_to 'Edit Application', edit_adopter_application_path(app.id) %>

--- a/app/views/adoption_application_reviews/_search_results.html.erb
+++ b/app/views/adoption_application_reviews/_search_results.html.erb
@@ -1,17 +1,19 @@
-<%# refactor to get rid of duplication? %>
+<%# @dog, @dogs are defined in the adoption_application_reviews controller %>
 
-<% if @dog.nil?%>
+<% if @dog.nil? ? @collection = @dogs : @collection = @dog %>
 
-  <% @dogs.each do |dog| %>
+  <% @collection.each do |dog| %>
     <%= link_to dog.name, dog_path(dog) %>
     
     <div class='card mb-4'>
       <% dog.adopter_applications.each do |app|%>
-        <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>"> 
-          Application Status: <%= app.status.titleize%>
+            
+        <div>
+          Name: <%= app.adopter_account.user.first_name %>
+                <%= app.adopter_account.user.last_name %>
         </div>
-    
-        <div class='mb-3'>
+
+        <div>
           <%= link_to 'Adopter Profile', profile_review_path(app.adopter_account.adopter_profile.id) %>
           <%= link_to 'Edit Application', edit_adopter_application_path(app.id) %>
 
@@ -22,26 +24,14 @@
                                                                 turbo_confirm: "Click OK to finalize this adoption." } %>
           <% end %>
         </div>
+
+        <div class="mb-3 <%= 'fw-bold' if app.status == 'withdrawn' %>"> 
+          Application Status: <%= app.status.titleize%>
+        </div>
+
       <% end %>
     </div>
 
   <% end %>
-
-<% else %>
-
-  <%= link_to @dog.name, dog_path(@dog) %>
-    
-    <div class='card'>
-      <% @dog.adopter_applications.each do |app|%>
-      <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>"> Application Status: <%= app.status.titleize%></div>
-      <p>Applicant Profile: <%= link_to 'Adopter Profile', 
-                                        profile_review_path(app.adopter_account.adopter_profile.id) %>
-      <%= link_to 'Edit Application', edit_adopter_application_path(app.id) %>
-      <%= link_to 'Adoption', create_adoption_path(dog_id: @dog.id, 
-                                                     adopter_account_id: app.adopter_account.id),
-                                                     data: { turbo_method: :post, 
-                                                             turbo_confirm: "Click OK to finalize this adoption." } %>
-      <% end %>
-    </div>
 
 <% end %>

--- a/app/views/adoption_application_reviews/edit.html.erb
+++ b/app/views/adoption_application_reviews/edit.html.erb
@@ -10,6 +10,7 @@
   <% else %>
     <%= form.select(:status, AdopterApplication.statuses.keys.map {|status| [status.titleize,status]}) %>
   <% end %>
+  
   <%= form.label :notes %><br>
   <%= form.text_area :notes %><br>
 

--- a/app/views/adoption_application_reviews/edit.html.erb
+++ b/app/views/adoption_application_reviews/edit.html.erb
@@ -4,11 +4,14 @@
 <%= link_to 'Adopter Profile', profile_review_path(@application.adopter_account.adopter_profile.id) %>
 
 <%= form_with model: @application, :url => adopter_application_path do |form| %>
-    <%= form.label :status %>
+  <%= form.label :status %>
+  <% if @application.status == 'withdrawn' %>
+    <p class='fw-bold'><%= @application.status %></p>
+  <% else %>
     <%= form.select(:status, AdopterApplication.statuses.keys.map {|status| [status.titleize,status]}) %>
-    <%= form.label :notes %>
-    <%= form.text_area :notes %>
+  <% end %>
+  <%= form.label :notes %><br>
+  <%= form.text_area :notes %><br>
 
-    <%= form.submit %>
-
+  <%= form.submit %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get '/adoptable_dogs/:id', to: 'adoptable_dogs#show', as: 'adoptable_dog'
 
   post 'create_adopter_application', to: 'adopter_applications#create'
-  delete 'destroy_adopter_application', to: 'adopter_applications#destroy'
+  patch 'update_adopter_application', to: 'adopter_applications#update'
 
   post 'create_adoption', to: 'adoptions#create'
 

--- a/db/migrate/20220807233806_add_column_to_adopter_applications.rb
+++ b/db/migrate/20220807233806_add_column_to_adopter_applications.rb
@@ -1,0 +1,5 @@
+class AddColumnToAdopterApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :adopter_applications, :profile_show, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_05_222108) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_07_233806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_222108) do
     t.datetime "updated_at", null: false
     t.integer "status", default: 0
     t.text "notes"
+    t.boolean "profile_show", default: true
     t.index ["adopter_account_id"], name: "index_adopter_applications_on_adopter_account_id"
     t.index ["dog_id"], name: "index_adopter_applications_on_dog_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,4 +4,7 @@
 # Examples:
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+#   Character.create(name: "Luke", movie: movies.first
+
+
+


### PR DESCRIPTION
Add features to adoption review process that allows adopters to withdraw applications, and remove applications from their profile if the status is withdrawn or adoption made. 
Allows staff to see if an application is withdrawn and prevents them changing this status in the application. Adoption button also comes up if staff select adoption made from dropdown in application. 
Adoptions controller, now checks in before action that user is the verified staff and in same organization