### PR TITLE
Active storage fix

### DIFF
--- a/app/controllers/organization_dogs_controller.rb
+++ b/app/controllers/organization_dogs_controller.rb
@@ -65,7 +65,7 @@ class OrganizationDogsController < ApplicationController
                                 :breed,
                                 :size,
                                 :description,
-                                images: [])
+                                append_images: [])
   end
 
   # check before all actions that user is: signed in, staff, verified

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -11,7 +11,7 @@ class Dog < ApplicationRecord
   validates :sex, presence: true
   validates :description, presence: true, length: { maximum: 500 }
   validates :images, content_type: { in: ['image/png', 'image/jpeg'], message: 'must be PNG or JPEG' },
-                     limit: { max: 5, message: 'between one and five allowed' },
+                     limit: { max: 5, message: '- 5 maximum' },
                      size: { between: 100.kilobyte..2.megabytes,
                              message: 'file size must be between 100kb and 2Mb' }
 

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -14,4 +14,9 @@ class Dog < ApplicationRecord
                      limit: { max: 5, message: 'between one and five allowed' },
                      size: { between: 100.kilobyte..2.megabytes,
                              message: 'file size must be between 100kb and 2Mb' }
+
+  # using.attach per the recommendation in rails server output for appending images
+  def append_images=(attachables)
+    images.attach(attachables)
+  end
 end

--- a/app/views/organization_dogs/_form.html.erb
+++ b/app/views/organization_dogs/_form.html.erb
@@ -84,15 +84,22 @@
           <% end %>
         </div>
 
-        <div class='form-group mb-3'>
+        <div class='mb-3'>
           <% if dog.images.attached? %>
             <h5>Uploaded Images</h5>
+            <div class='row row-cols-1 row-cols-md-5 g-6'>
               <% dog.images.each do |image| %>
                 <% if image.created_at %>
-                  <%= image_tag image, width: '75' %>
-                  <%= link_to 'Delete', purge_attachment_path(image), data: { turbo_method: "delete" } %>
+                  <div class='card'>
+                    <%= image_tag image, width: '75' %>
+                    <%= link_to 'Delete', 
+                                purge_attachment_path(image), 
+                                data: { turbo_method: "delete" },
+                                class: 'small' %>
+                  </div>
                 <% end %>
               <% end %>
+            </div>
           <% end %>
         </div>
 

--- a/app/views/organization_dogs/_form.html.erb
+++ b/app/views/organization_dogs/_form.html.erb
@@ -76,8 +76,8 @@
         </div>
 
         <div class='form-group mb-3'>
-          <h5 class=''><%= form.label :images %></h5>
-          <%= form.file_field :images, multiple: true, class: "custom-attachments" %>
+          <h5 class=''><%= form.label :append_images %></h5>
+          <%= form.file_field :append_images, multiple: true, class: "custom-attachments" %>
           
           <% dog.errors.full_messages_for(:images).each do |message| %>
             <div class="alert alert-danger mt-1" role="alert"><%= message %></div>

--- a/app/views/organization_dogs/_form.html.erb
+++ b/app/views/organization_dogs/_form.html.erb
@@ -88,8 +88,10 @@
           <% if dog.images.attached? %>
             <h5>Uploaded Images</h5>
               <% dog.images.each do |image| %>
-                <%= image_tag image, width: '75' %>
-                <%= link_to 'Delete', purge_attachment_path(image), data: { turbo_method: "delete" } %>
+                <% if image.created_at %>
+                  <%= image_tag image, width: '75' %>
+                  <%= link_to 'Delete', purge_attachment_path(image), data: { turbo_method: "delete" } %>
+                <% end %>
               <% end %>
           <% end %>
         </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,8 +59,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Allow image uploads to be appended rather than delete all existing on a new upload
-  config.active_storage.replace_on_assign_to_many = false
+  # Per the deprecation warning in rails server output re this config, set it to true
+  config.active_storage.replace_on_assign_to_many = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,8 +40,8 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Allow image uploads to be appended rather than delete all existing on a new upload
-  config.active_storage.replace_on_assign_to_many = false
+  # Per the deprecation warning in rails server output re this config, set it to true
+  config.active_storage.replace_on_assign_to_many = true
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
Fix active storage bug where uploads that fail validation were causing an error on rendering the edit form with attachments because the failed attachment was not saving and therefore had no id for the delete button url.