### PR TITLE
Devise customization

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit "Resend confirmation instructions", data: { turbo: false } %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password" %>
+    <%= f.submit "Change my password", data: { turbo: false } %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "Send me reset password instructions", data: { turbo: false } %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,6 +22,16 @@
   </div>
 
   <div class="field">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :last_name %><br />
+    <%= f.text_field :last_name %>
+  </div>
+
+  <div class="field">
     <%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
@@ -32,7 +42,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "Update", data: { turbo: false } %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -48,7 +48,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "Sign up", data: { turbo: false } %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "Log in", data: { turbo: false } %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,16 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2>
+    <%# <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    <%# /h2> %>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <div class="alert alert-danger mt-1" role="alert">
+          <%= message %>
+        </div>
       <% end %>
     </ul>
   </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -17,7 +17,8 @@
   <% end %>
 
 
-  <%= link_to 'Log out', destroy_user_session_path, data: { turbo_method: "delete" } %>
+  <%= link_to 'Log out', destroy_user_session_path, data: { turbo_method: "delete" } %><br>
+  <%= link_to 'Account Settings', edit_user_registration_path %>
 
 <% else %>
   <p>You are not logged in</p>


### PR DESCRIPTION
Fix flash messages on failed login or sign up by setting data turbo to false on the submit buttons on each form. This is a workaround solution that is a compromise between speed/complexity and functionality. It was quick and easy to do, and will be easy to remove in future, but stops turbo stream and results in a slower user experience. It is a reasonable solution until I find a more official solution. Add first and last name fields to the edit user settings form.