### PR TITLE
tests for editing user profile

### DIFF
--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,7 +10,7 @@ user_one:
   first_name: Ben
   last_name: Jo
   email: test@test.com
-  encrypted_password: password
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   tos_agreement: 1
 
 # verified staff
@@ -18,7 +18,7 @@ user_two:
   first_name: Staffy
   last_name: McStaffface
   email: testes@test.com
-  encrypted_password: password
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   tos_agreement: 1
 
 # unverified staff
@@ -26,7 +26,7 @@ user_three:
   first_name: unverified
   last_name: McStaffface
   email: testes@testes.com
-  encrypted_password: password
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   tos_agreement: 1
 
 # adopter without a profile
@@ -34,5 +34,5 @@ user_four:
   first_name: Billy
   last_name: Noprofile
   email: test@test123.com
-  encrypted_password: password
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   tos_agreement: 1

--- a/test/integration/user_account_test.rb
+++ b/test/integration/user_account_test.rb
@@ -100,6 +100,29 @@ class UserAccountTest < ActionDispatch::IntegrationTest
     assert users(:user_four).valid_password?('password'), 'Password updated without proper authorization'
   end
 
+  test 'user can update their password and see success flash' do
+    sign_in users(:user_four)
+
+    put '/users',
+    params: { user:
+              {
+                email: 'test@test123.com',
+                first_name: 'Billy',
+                last_name: 'Noprofile',
+                password: 'newpassword',
+                password_confirmation: 'newpassword',
+                current_password: 'password'
+              },
+      commit: 'Update'
+    }
+
+    assert_response :redirect
+    assert_equal 'Your account has been updated successfully.', flash[:notice]
+
+    users(:user_four).reload
+    assert users(:user_four).valid_password?('newpassword'), 'Updated password is not valid'
+  end
+
   test "user can delete their account" do
     sign_in users(:user_four)
     assert(User.find_by(email: 'test@test123.com'))

--- a/test/integration/user_account_test.rb
+++ b/test/integration/user_account_test.rb
@@ -53,6 +53,29 @@ class UserAccountTest < ActionDispatch::IntegrationTest
     assert(StaffAccount.find_by(organization_id: 1))
   end
 
+  test 'error messages should appear if edit profile form is submitted without data' do
+    sign_in users(:user_four)
+
+    put '/users',
+    params: { user:
+              {
+                email: '',
+                first_name: '',
+                last_name: '',
+                password: '',
+                password_confirmation: '',
+                current_password: 'password'
+              },
+      commit: 'Update'
+    }
+
+    assert_response :success
+    assert_select 'div.alert', count: 3
+    assert_select 'div.alert', "Email can't be blank"
+    assert_select 'div.alert', "First name can't be blank"
+    assert_select 'div.alert', "Last name can't be blank"
+  end
+
   test "user can delete their account" do
     sign_in users(:user_four)
     assert(User.find_by(email: 'test@test123.com'))

--- a/test/integration/user_account_test.rb
+++ b/test/integration/user_account_test.rb
@@ -76,6 +76,30 @@ class UserAccountTest < ActionDispatch::IntegrationTest
     assert_select 'div.alert', "Last name can't be blank"
   end
 
+  test 'user cannot update their profile with invalid password and should see error message' do
+    sign_in users(:user_four)
+
+    put '/users',
+    params: { user:
+              {
+                email: 'test@test123.com',
+                first_name: 'Billy',
+                last_name: 'Noprofile',
+                password: '',
+                password_confirmation: '',
+                current_password: 'badpass'
+              },
+      commit: 'Update'
+    }
+
+    assert_response :success
+    assert_select 'div.alert', count: 1
+    assert_select 'div.alert', 'Current password is invalid'
+
+    users(:user_four).reload
+    assert users(:user_four).valid_password?('password'), 'Password updated without proper authorization'
+  end
+
   test "user can delete their account" do
     sign_in users(:user_four)
     assert(User.find_by(email: 'test@test123.com'))

--- a/test/integration/user_account_test.rb
+++ b/test/integration/user_account_test.rb
@@ -123,6 +123,30 @@ class UserAccountTest < ActionDispatch::IntegrationTest
     assert users(:user_four).valid_password?('newpassword'), 'Updated password is not valid'
   end
 
+  test 'user can update their first name and see success flash' do
+    sign_in users(:user_four)
+
+    put '/users',
+    params: { user:
+              {
+                email: 'test@test123.com',
+                first_name: 'Etzio',
+                last_name: 'Auditore',
+                password: '',
+                password_confirmation: '',
+                current_password: 'password'
+              },
+      commit: 'Update'
+    }
+
+    assert_response :redirect
+    assert_equal 'Your account has been updated successfully.', flash[:notice]
+
+    users(:user_four).reload
+    assert_equal 'Etzio',  users(:user_four).first_name
+    assert_equal 'Auditore',  users(:user_four).last_name
+  end
+
   test "user can delete their account" do
     sign_in users(:user_four)
     assert(User.find_by(email: 'test@test123.com'))


### PR DESCRIPTION
**Summary of changes:** 
`test/fixtures/users.yml`
 I was unable to send a PUT request in my integration tests since I kept receiving an invalid hash error. After a lot of debugging, it turns out the issues is that the fixture users' passwords were not properly encrypted (using Devise's Encryptor module).
 So I went ahead and updated all the user passwords accordingly.
 
 `test/integration/user_account_test.rb`
 I created test for editing user profiles:
 * blank edit form submission errors
 * invalid password when editing
 * successful password update
 * successful first/last name update
 
 And if you're curious, the user fixtures file didn't have a newline at the end, so that was thrown in there too!
Please let me know if you have any suggestions, I do realize I might have stretched the scope of this issue just a bit.

**Closes issue:** #43 