### PR TITLE
Adoption application reviews tests

### DIFF
--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -2,6 +2,11 @@ require "test_helper"
 
 class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
 
+  setup do
+    @adopter_application = adopter_applications(:adopter_application_one)
+    @adopter = @adopter_application.adopter_account.user
+  end
+
   test "verified staff can see all applications" do
     sign_in users(:user_two)
 
@@ -9,7 +14,7 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select 'a', {
-      count: AdopterApplication.count, text: 'Edit Application'
+      count: Dog.org_dogs_with_apps(users(:user_two).staff_account.organization_id).count, text: 'Adopter Profile'
     }
   end
 
@@ -28,9 +33,9 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
 
     get '/adopter_applications'
 
-    assert_select 'a', AdopterApplication.first.dog.name
-    assert_select 'p', "Applicant: #{AdopterApplication.first.adopter_account.user.first_name}
-                      #{AdopterApplication.first.adopter_account.user.last_name}"
+    assert_select 'a', @adopter_application.dog.name
+    assert_select 'p', "Applicant: #{@adopter.first_name}
+                      #{@adopter.last_name}"
     assert_select 'a', 'Adopter Profile'
     assert_select 'a', 'Edit Application'
   end

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -19,6 +19,8 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
     get '/adopter_applications'
 
     assert_response :redirect
+    follow_redirect!
+    assert_equal 'Unauthorized action.', flash[:alert]
   end
 
   test "all expected elements of an application are shown" do

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
+
+  test "verified staff can see all applications" do
+    sign_in users(:user_two)
+
+    get '/adopter_applications'
+
+    assert_response :success
+    assert_select 'a', {
+      count: AdopterApplication.count, text: 'Edit Application'
+    }
+  end
+end

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -20,4 +20,16 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
   end
+
+  test "all expected elements of an application are shown" do
+    sign_in users(:user_two)
+
+    get '/adopter_applications'
+
+    assert_select 'a', AdopterApplication.first.dog.name
+    assert_select 'p', "Applicant: #{AdopterApplication.first.adopter_account.user.first_name}
+                      #{AdopterApplication.first.adopter_account.user.last_name}"
+    assert_select 'a', 'Adopter Profile'
+    assert_select 'a', 'Edit Application'
+  end
 end

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -12,4 +12,12 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
       count: AdopterApplication.count, text: 'Edit Application'
     }
   end
+
+  test "unverified staff cannot access the page" do
+    sign_in users(:user_three)
+
+    get '/adopter_applications'
+
+    assert_response :redirect
+  end
 end


### PR DESCRIPTION
These tests are for the first bullet point of Issue #49. I _think_ the name of the test file is appropriate.

3 total tests to check that:
- verified staff can see all applications
- unverified staff cannot access the page
- all expected elements of an application are shown

Hopefully these are in line with how you'd write such tests!