### PR TITLE
Fix command for installing figaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To set this application up locally:
 * Fork the repository and copy SSH key
 * `git clone <'SSH Key'>` to download application locally
 * `bundle install` to install gems (you may have to change gem 'sassc-rails' to gem 'sassc', "~> 2.1.0")
-* `bundle exec install figaro` 
+* `bundle exec figaro install`
 * add your PostgreSQL database username and database password to `config/application.yml` as ENV variables
 * `rails db:migrate` to run all migrations
 * `rails db:seed` to load seed data


### PR DESCRIPTION
I ran into an error when trying to install figaro by running `bundle exec install figaro`. I then realized that the correct command is `bundle exec figaro install`.