### PR TITLE
set up fixture for an adoption application that has been withdrawn an…

### DIFF
--- a/test/fixtures/adopter_applications.yml
+++ b/test/fixtures/adopter_applications.yml
@@ -7,3 +7,9 @@ adopter_application_one:
 adopter_application_two:
   dog: dog_five
   adopter_account: adopter_account_one
+
+adopter_application_three:
+  dog: dog_two
+  adopter_account: adopter_account_one
+  profile_show: false
+  status: 3

--- a/test/integration/adopter_applications_page_test.rb
+++ b/test/integration/adopter_applications_page_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
   setup do
-    @application_id = AdopterApplication.first.id
+    @application_id = adopter_applications(:adopter_application_one).id
   end
 
   test "Adopter without profile cannot access adopter applications route" do

--- a/test/system/adopter_application_edit_test.rb
+++ b/test/system/adopter_application_edit_test.rb
@@ -1,0 +1,24 @@
+require "application_system_test_case"
+
+class AdopterApplicationEditTest < ApplicationSystemTestCase
+
+  setup do
+    @application_id = adopter_applications(:adopter_application_three).id
+    sign_in users(:user_two)
+    visit edit_adopter_application_path(@application_id)
+  end
+
+  test "Clicking the information icon makes the information box appear and disappear" do
+    assert_selector "h1", text: "Ben Jo's application for Adopted"
+    assert_selector "p.explanation", count: 0
+    find("img.ms-2").click
+    assert_selector "p.explanation", count: 1
+    find("img.ms-2").click
+    assert_selector "p.explanation", count: 0
+  end
+
+  test "Application status select dropdown contains all expected options" do 
+    assert_equal page.all('select#adopter_application_status option').map(&:value),
+      ['awaiting_review', 'under_review', 'adoption_pending', 'withdrawn', 'successful_applicant']
+  end
+end

--- a/test/system/adopter_profile_forms_test.rb
+++ b/test/system/adopter_profile_forms_test.rb
@@ -5,12 +5,12 @@ class AdopterProfileFormsTest < ApplicationSystemTestCase
   setup do
     sign_in users(:user_one)
     visit profile_path
-
     click_on "Edit Profile"
-    assert_selector "h1", text: "EDIT PROFILE"
   end
 
   test "Text areas appear after radio check and all text areas have character counter and text areas disappear after radio check" do
+    assert_selector "h1", text: "EDIT PROFILE"
+
     fill_in "Briefly describe your ideal dog", with: "Big and fluffy."
     fill_in "Briefly describe your lifestyle", with: "Big and fluffy."
     fill_in "Briefly describe activities you will do with your dog", with: "Big and fluffy."


### PR DESCRIPTION
…d removed from profile, make test for adopter application edit route to check clicking the info icon makes the info box appear and disappear, move assertion from setup to test in adopter profile forms test