### PR TITLE
Adoption application reviews tests: staff can edit app status, add notes

### DIFF
--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -43,16 +43,14 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
   test "verified staff can edit an adoption application status" do
     sign_in users(:user_two)
 
-    put "/adopter_applications/#{@adopter_application.id}",
-      params: { adopter_application:
-        {
-          status: 'under_review', notes: ''
-        }, commit: 'Save', id: @adopter_application.id
-      }
-
-    assert_response :redirect
-    follow_redirect!
-    assert_select 'div', 'Status: Under Review'
+    assert_changes 'AdopterApplication.find(@adopter_application.id).status' do
+      put "/adopter_applications/#{@adopter_application.id}",
+        params: { adopter_application:
+          {
+            status: 'under_review', notes: ''
+          }, commit: 'Save', id: @adopter_application.id
+        }
+    end
   end
 
   test "verified staff can add notes to an application" do

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -39,4 +39,19 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
     assert_select 'a', 'Adopter Profile'
     assert_select 'a', 'Edit Application'
   end
+
+  test "verified staff can edit an adoption application status" do
+    sign_in users(:user_two)
+
+    put "/adopter_applications/#{@adopter_application.id}",
+      params: { adopter_application:
+        {
+          status: 'under_review', notes: ''
+        }, commit: 'Save', id: @adopter_application.id
+      }
+
+    assert_response :redirect
+    follow_redirect!
+    assert_select 'div', 'Status: Under Review'
+  end
 end

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -54,4 +54,21 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_select 'div', 'Status: Under Review'
   end
+
+  test "verified staff can add notes to an application" do
+    sign_in users(:user_two)
+
+    put "/adopter_applications/#{@adopter_application.id}",
+      params: { adopter_application:
+        {
+          status: 'under_review', notes: 'some notes'
+        }, commit: 'Save', id: @adopter_application.id
+      }
+
+    assert_response :redirect
+
+    get "/adopter_applications/#{@adopter_application.id}/edit"
+
+    assert_select 'textarea', 'some notes'
+  end
 end

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -43,7 +43,7 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
   test "verified staff can edit an adoption application status" do
     sign_in users(:user_two)
 
-    assert_changes 'AdopterApplication.find(@adopter_application.id).status' do
+    assert_changes 'AdopterApplication.find(@adopter_application.id).status', from: 'awaiting_review', to: 'under_review' do
       put "/adopter_applications/#{@adopter_application.id}",
         params: { adopter_application:
           {

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -53,6 +53,21 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "unverified staff cannot edit an adoption application status" do
+    sign_in users(:user_three)
+
+    put "/adopter_applications/#{@adopter_application.id}",
+    params: { adopter_application:
+      {
+        status: 'under_review', notes: ''
+      }, commit: 'Save', id: @adopter_application.id
+    }
+
+    assert_response :redirect
+    follow_redirect!
+    assert_equal 'Unauthorized action.', flash[:alert]
+  end
+
   test "verified staff can add notes to an application" do
     sign_in users(:user_two)
 

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -84,4 +84,19 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
 
     assert_select 'textarea', 'some notes'
   end
+
+  test "unverified staff cannot add notes to an application" do
+    sign_in users(:user_three)
+
+    put "/adopter_applications/#{@adopter_application.id}",
+      params: { adopter_application:
+        {
+          status: 'under_review', notes: 'some notes'
+        }, commit: 'Save', id: @adopter_application.id
+      }
+
+    assert_response :redirect
+    follow_redirect!
+    assert_equal 'Unauthorized action.', flash[:alert]
+  end
 end


### PR DESCRIPTION
More tests for Issue #49 

**First Test Struggles**

Initially, I tried writing the first test using an `assert_changes` assertion, but it kept failing due to the app status not changing. This was odd because I could see that the `put` request was reaching the `update` action, and passing the `if` statement's conditions (I verified it by adding `raise "hello"` under the `if` statement, and `"hello"` would be raised).

The reason it was failing has something to do with the way Minitest references the fixtures, or maybe it's just how fixtures work. It essentially seemed to be comparing the original fixture app's status not with the updated fixture app status, but with the same original app status. I tried a lot of things but just couldn't get it to work, so I settled for this other approach.

**Add Tests for Unverified Staff?**

I'm thinking you might also want tests to ensure that unverified staff cannot make these changes to an application?