### PR TITLE
/donate page - push the footer to the bottom

### DIFF
--- a/app/views/static_pages/donate.html.erb
+++ b/app/views/static_pages/donate.html.erb
@@ -1,4 +1,4 @@
-<section class="pt-5 pb-5" id="donate">
+<section class="pt-5" id="donate">
   <div class="container mb-md-5 mt-md-5">
 
     <!--page heading-->


### PR DESCRIPTION
Closes Issue #70

Luckily this was a simple fix, we just needed to remove the `pb-5` class from the `section` that contains the page contents.