### PR TITLE
/donate page - push the footer to the bottom

### DIFF
--- a/app/views/static_pages/donate.html.erb
+++ b/app/views/static_pages/donate.html.erb
@@ -27,5 +27,6 @@
         </p>
       </div>
     </div> <!--row-->
-  </div> <!-- cotainer >
+
+  </div> <!--container-->
 </section>


### PR DESCRIPTION
Closes Issue #70 

My last "solution" (in the closed PR) was a bit silly, I found the real issue now. The `</section>` closing tag had been mistakenly commented out, which was causing the footer to be grouped in with the section's contents. And because of the pb-5 class on the section, there was padding below the footer