### PR TITLE
Add test that ensures adopted dog is not shown as adoptable dog

### DIFF
--- a/test/integration/adoptable_dog_show_test.rb
+++ b/test/integration/adoptable_dog_show_test.rb
@@ -4,6 +4,7 @@ class AdoptableDogShowTest < ActionDispatch::IntegrationTest
 
   setup do
     @dog_id = dogs(:dog_three).id
+    @adopted_dog_id = dogs(:dog_two).id
   end
 
   test "unauthenticated users see create account prompt and link" do
@@ -94,6 +95,13 @@ class AdoptableDogShowTest < ActionDispatch::IntegrationTest
     @dog_id = dogs(:dog_one).id
     get "/adoptable_dogs/#{@dog_id}"
     assert_select 'h1', "#{dogs(:dog_one).name} (Adoption Pending)"
+  end
+  
+  test "an adopted dog can't be shown as an adoptable dog" do
+    get "/adoptable_dogs/#{@adopted_dog_id}"
+    assert_response :redirect
+    follow_redirect!
+    assert_equal 'You can only view dogs that need adoption.', flash[:alert]
   end
 
 end


### PR DESCRIPTION
Closes Issue #89 

This was a quick and easy test. I wasn't sure if I should just use `dogs(:dog_two).id` in the `get` request itself or create an instance variable, but I opted for the latter because it may come in handy for future tests perhaps?