### PR TITLE
Exchange explict count assertions with more flexible active record collection counts

### DIFF
--- a/test/integration/adopter_applications_page_test.rb
+++ b/test/integration/adopter_applications_page_test.rb
@@ -25,7 +25,13 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_select 'h1', 'Adoption Applications'
 
     # two Withdraw buttons and one navbar logout button
-    assert_select 'form', { count: 3 }
+    visible_applications_count = users(:user_one)
+                                .adopter_account
+                                .adopter_applications
+                                .where.not(status: ['adoption_made'])
+                                .where(profile_show: true)
+                                .count
+    assert_select 'form', { count: visible_applications_count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
     end
@@ -48,7 +54,13 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_select 'h1', 'Adoption Applications'
 
     # two Withdraw buttons and one navbar logout button
-    assert_select 'form', { count: 3 }
+    visible_applications_count = users(:user_one)
+                                .adopter_account
+                                .adopter_applications
+                                .where.not(status: ['adoption_made'])
+                                .where(profile_show: true)
+                                .count
+    assert_select 'form', { count: visible_applications_count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
     end
@@ -74,7 +86,13 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_select 'h1', 'Adoption Applications'
 
     # One Withdraw button and one navbar logout button
-    assert_select 'form', { count: 2 }
+    visible_applications_count = users(:user_one)
+                                .adopter_account
+                                .adopter_applications
+                                .where.not(status: ['adoption_made'])
+                                .where(profile_show: true)
+                                .count
+    assert_select 'form', { count: visible_applications_count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
     end
@@ -110,7 +128,13 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     get '/my_applications'
     assert_response :success
-    assert_select 'form', { count: 3 }
+    visible_applications_count = users(:user_one)
+                                .adopter_account
+                                .adopter_applications
+                                .where.not(status: ['adoption_made'])
+                                .where(profile_show: true)
+                                .count
+    assert_select 'form', { count: visible_applications_count + 1 }
 
     # withdraw and remove in one request
     patch '/my_application',
@@ -124,7 +148,13 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     follow_redirect!
-    assert_select 'form', { count: 2 }
+    visible_applications_count = users(:user_one)
+                                .adopter_account
+                                .adopter_applications
+                                .where.not(status: ['adoption_made'])
+                                .where(profile_show: true)
+                                .count
+    assert_select 'form', { count: visible_applications_count + 1 }
     logout
 
     sign_in users(:user_two)
@@ -140,6 +170,12 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     sign_in users(:user_one)
     get '/my_applications'
     assert_response :success
-    assert_select 'form', { count: 3 }
+    visible_applications_count = users(:user_one)
+                                .adopter_account
+                                .adopter_applications
+                                .where.not(status: ['adoption_made'])
+                                .where(profile_show: true)
+                                .count
+    assert_select 'form', { count: visible_applications_count + 1 }
   end
 end

--- a/test/integration/adopter_applications_page_test.rb
+++ b/test/integration/adopter_applications_page_test.rb
@@ -26,11 +26,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     # two Withdraw buttons and one navbar logout button
     visible_applications_count = users(:user_one)
-                                .adopter_account
-                                .adopter_applications
-                                .where.not(status: ['adoption_made'])
-                                .where(profile_show: true)
-                                .count
+                                 .adopter_account
+                                 .adopter_applications
+                                 .where.not(status: ['adoption_made'])
+                                 .where(profile_show: true)
+                                 .count
     assert_select 'form', { count: visible_applications_count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
@@ -55,11 +55,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     # two Withdraw buttons and one navbar logout button
     visible_applications_count = users(:user_one)
-                                .adopter_account
-                                .adopter_applications
-                                .where.not(status: ['adoption_made'])
-                                .where(profile_show: true)
-                                .count
+                                 .adopter_account
+                                 .adopter_applications
+                                 .where.not(status: ['adoption_made'])
+                                 .where(profile_show: true)
+                                 .count
     assert_select 'form', { count: visible_applications_count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
@@ -87,11 +87,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     # One Withdraw button and one navbar logout button
     visible_applications_count = users(:user_one)
-                                .adopter_account
-                                .adopter_applications
-                                .where.not(status: ['adoption_made'])
-                                .where(profile_show: true)
-                                .count
+                                 .adopter_account
+                                 .adopter_applications
+                                 .where.not(status: ['adoption_made'])
+                                 .where(profile_show: true)
+                                 .count
     assert_select 'form', { count: visible_applications_count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
@@ -129,11 +129,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     get '/my_applications'
     assert_response :success
     visible_applications_count = users(:user_one)
-                                .adopter_account
-                                .adopter_applications
-                                .where.not(status: ['adoption_made'])
-                                .where(profile_show: true)
-                                .count
+                                 .adopter_account
+                                 .adopter_applications
+                                 .where.not(status: ['adoption_made'])
+                                 .where(profile_show: true)
+                                 .count
     assert_select 'form', { count: visible_applications_count + 1 }
 
     # withdraw and remove in one request
@@ -149,11 +149,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     follow_redirect!
     visible_applications_count = users(:user_one)
-                                .adopter_account
-                                .adopter_applications
-                                .where.not(status: ['adoption_made'])
-                                .where(profile_show: true)
-                                .count
+                                 .adopter_account
+                                 .adopter_applications
+                                 .where.not(status: ['adoption_made'])
+                                 .where(profile_show: true)
+                                 .count
     assert_select 'form', { count: visible_applications_count + 1 }
     logout
 
@@ -171,11 +171,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     get '/my_applications'
     assert_response :success
     visible_applications_count = users(:user_one)
-                                .adopter_account
-                                .adopter_applications
-                                .where.not(status: ['adoption_made'])
-                                .where(profile_show: true)
-                                .count
+                                 .adopter_account
+                                 .adopter_applications
+                                 .where.not(status: ['adoption_made'])
+                                 .where(profile_show: true)
+                                 .count
     assert_select 'form', { count: visible_applications_count + 1 }
   end
 end

--- a/test/integration/adopter_applications_page_test.rb
+++ b/test/integration/adopter_applications_page_test.rb
@@ -4,6 +4,11 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
   setup do
     @application_id = adopter_applications(:adopter_application_one).id
+    @visible_applications = users(:user_one)
+                            .adopter_account
+                            .adopter_applications
+                            .where.not(status: ['adoption_made'])
+                            .where(profile_show: true)
   end
 
   test "Adopter without profile cannot access adopter applications route" do
@@ -25,13 +30,7 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_select 'h1', 'Adoption Applications'
 
     # two Withdraw buttons and one navbar logout button
-    visible_applications_count = users(:user_one)
-                                 .adopter_account
-                                 .adopter_applications
-                                 .where.not(status: ['adoption_made'])
-                                 .where(profile_show: true)
-                                 .count
-    assert_select 'form', { count: visible_applications_count + 1 }
+    assert_select 'form', { count: @visible_applications.reload.count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
     end
@@ -54,13 +53,7 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_select 'h1', 'Adoption Applications'
 
     # two Withdraw buttons and one navbar logout button
-    visible_applications_count = users(:user_one)
-                                 .adopter_account
-                                 .adopter_applications
-                                 .where.not(status: ['adoption_made'])
-                                 .where(profile_show: true)
-                                 .count
-    assert_select 'form', { count: visible_applications_count + 1 }
+    assert_select 'form', { count: @visible_applications.reload.count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
     end
@@ -86,13 +79,7 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     assert_select 'h1', 'Adoption Applications'
 
     # One Withdraw button and one navbar logout button
-    visible_applications_count = users(:user_one)
-                                 .adopter_account
-                                 .adopter_applications
-                                 .where.not(status: ['adoption_made'])
-                                 .where(profile_show: true)
-                                 .count
-    assert_select 'form', { count: visible_applications_count + 1 }
+    assert_select 'form', { count: @visible_applications.reload.count + 1 }
     assert_select 'form' do
       assert_select 'button', 'Withdraw'
     end
@@ -128,13 +115,7 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     get '/my_applications'
     assert_response :success
-    visible_applications_count = users(:user_one)
-                                 .adopter_account
-                                 .adopter_applications
-                                 .where.not(status: ['adoption_made'])
-                                 .where(profile_show: true)
-                                 .count
-    assert_select 'form', { count: visible_applications_count + 1 }
+    assert_select 'form', { count: @visible_applications.reload.count + 1 }
 
     # withdraw and remove in one request
     patch '/my_application',
@@ -148,13 +129,7 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     follow_redirect!
-    visible_applications_count = users(:user_one)
-                                 .adopter_account
-                                 .adopter_applications
-                                 .where.not(status: ['adoption_made'])
-                                 .where(profile_show: true)
-                                 .count
-    assert_select 'form', { count: visible_applications_count + 1 }
+    assert_select 'form', { count: @visible_applications.reload.count + 1 }
     logout
 
     sign_in users(:user_two)
@@ -170,12 +145,6 @@ class AdopterApplicationsPageTest < ActionDispatch::IntegrationTest
     sign_in users(:user_one)
     get '/my_applications'
     assert_response :success
-    visible_applications_count = users(:user_one)
-                                 .adopter_account
-                                 .adopter_applications
-                                 .where.not(status: ['adoption_made'])
-                                 .where(profile_show: true)
-                                 .count
-    assert_select 'form', { count: visible_applications_count + 1 }
+    assert_select 'form', { count: @visible_applications.reload.count + 1 }
   end
 end


### PR DESCRIPTION
Closes Issue #104 

Hopefully this looks good! I ensured that the tests pass even if a couple extra records are added in `test/fixtures/adopter_applications.yml`