### PR TITLE
Fix failing system test

### DIFF
--- a/test/system/adopter_application_edit_test.rb
+++ b/test/system/adopter_application_edit_test.rb
@@ -11,10 +11,12 @@ class AdopterApplicationEditTest < ApplicationSystemTestCase
   test "Clicking the information icon makes the information box appear and disappear" do
     assert_selector "h1", text: "Ben Jo's application for Adopted"
     assert_selector "p.explanation", count: 0
-    find("img.ms-2").click
-    assert_selector "p.explanation", count: 1
-    find("img.ms-2").click
-    assert_selector "p.explanation", count: 0
+
+    find("img.ms-2").click do |image|
+      assert_selector "p.explanation", count: 1
+      image.click
+      assert_selector "p.explanation", count: 0
+    end
   end
 
   test "Application status select dropdown contains all expected options" do 


### PR DESCRIPTION
**Reason**
While upgrading Rails, I noticed that this system test was failing, so I updated it to make it more reliable.

**Additional information**
This was reverted by cf4d076970612bb2196689437e0d17cb01a04249, see #175 for a bit more details on the revert.

This restores commit b8b6b97077a20fd799a3322a3b56d2dc3fb95dc4 (see that commit's body for more information), which was reverted alongside upgrading the Rails patch version.

