### PR TITLE
[WIP] Add charts to active admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,4 +109,5 @@ group :test do
   gem 'simplecov', require: false
 end
 
+# Add chartkick for charts generation
 gem "chartkick", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,5 @@ group :test do
   # Code coverage analysis [https://github.com/simplecov-ruby/simplecov]
   gem 'simplecov', require: false
 end
+
+gem "chartkick", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (5.0.2)
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -377,6 +378,7 @@ DEPENDENCIES
   bootsnap
   bootstrap
   capybara
+  chartkick (~> 5.0)
   debug
   devise
   figaro

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -33,6 +33,21 @@ ActiveAdmin.register_page "Dashboard" do
             end
           end
         end
+        # Chartkick charts here
+        panel "Adoptions Over Time" do
+          line_chart Adoption.all.group_by { |adp| adp.created_at.beginning_of_month }
+                                 .map { |date, adps| [date, adps.count] }.to_h
+        end
+
+        panel "Donations Over Time" do
+          line_chart Donation.all.group_by { |donation| donation.created_at.beginning_of_month }
+                                 .map { |date, donations| [date, donations.count] }.to_h
+        end
+
+        panel "User Sign Ups Over Time" do
+          line_chart User.all.group_by { |user| user.created_at.beginning_of_month }
+                              .map { |date, users| [date, users.count] }.to_h
+        end
       end
     end
   end

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -1,1 +1,3 @@
 //= require active_admin/base
+//= require active_admin/base
+//= require chartkick

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,3 +9,6 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 # pin compiled bootstrap js
 pin "popper", to: 'popper.js', preload: true
 pin "bootstrap", to: 'bootstrap.min.js', preload: true
+
+pin "chartkick", to: "chartkick.js"
+pin "Chart.bundle", to: "Chart.bundle.js"

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -4,6 +4,9 @@ ActiveAdmin.setup do |config|
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
   #
+  # Load the Google API JS library
+  config.register_javascript 'https://www.google.com/jsapi'
+
   config.site_title = "Baja Pet Rescue"
 
   # Set the link url for the title. For example, to take

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -3,11 +3,10 @@ ActiveAdmin.setup do |config|
   #
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
-  #
+  config.site_title = "Baja Pet Rescue"
+
   # Load the Google API JS library
   config.register_javascript 'https://www.google.com/jsapi'
-
-  config.site_title = "Baja Pet Rescue"
 
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.


### PR DESCRIPTION
> It would be awesome to visualize some data from this application in active admin dashboard, such as adoptions, user sign ups and donations over time.

_Related issue:_ https://github.com/kasugaijin/baja-pet-rescue/issues/168

---

This PR is pretty self-descriptive as the title suggests. So, I think it does not need much explanation.

In this PR, I added the `chartkick` gem to generate charts in `activeadmin`.

There are 3 new sections in /admin/dashboard. `Adoptions Over Time`, `Donations Over Time` and `User Sign Ups Over Time`. They are all line charts. 

**_Example screenshot_**

![Screenshot 2023-07-21 at 20-09-17 Dashboard Baja Pet Rescue](https://github.com/kasugaijin/baja-pet-rescue/assets/93445248/257097a1-5717-4e1e-8094-f1b0719439d9)
